### PR TITLE
Adding Mutiny Gaming to the Vibby Esports Page

### DIFF
--- a/_pages/esports.html
+++ b/_pages/esports.html
@@ -90,17 +90,17 @@ description: Vibby esports homepage
     </div>
     <div class="partners">
       <div class="partner">
-        <a href="http://esportscenter.com/" target="_blank" title="Visit esports Center">
+        <a href="http://esportscenter.com/" target="_blank" title="Visit eSports Center">
           <img src="https://s3-eu-west-1.amazonaws.com/vibby-static/LandingPage/esports/partners/partner-esports-esportscenter.png" alt="Vibby Partner — esports Center" />
         </a>
       </div>
       <div class="partner">
-        <a href="http://www.aoe-esports.pt/" target="_blank" title="Visit AoE esports">
+        <a href="http://www.aoe-esports.pt/" target="_blank" title="Visit AoE eSports">
           <img src="https://s3-eu-west-1.amazonaws.com/vibby-static/LandingPage/esports/partners/partner-esports-aoe.png" alt="Vibby Partner — AoE esports" />
         </a>
       </div>
       <div class="partner">
-        <a href="http://www.reverieesports.com/" target="_blank" title="Visit Reverie esports">
+        <a href="http://www.reverieesports.com/" target="_blank" title="Visit Reverie Esports">
           <img src="https://s3-eu-west-1.amazonaws.com/vibby-static/LandingPage/esports/partners/partner-esports-reverie.png" alt="Vibby Partner — Reverie esports" />
         </a>
       </div>
@@ -120,8 +120,13 @@ description: Vibby esports homepage
         </a>
       </div>
       <div class="partner">
-        <a href="http://www.phoenixvainglory.com/" target="_blank" title="Visit CSadria">
+        <a href="http://www.phoenixvainglory.com/" target="_blank" title="Visit Team Phoenix">
           <img src="https://s3-eu-west-1.amazonaws.com/vibby-static/LandingPage/esports/partners/partner-esports-phoenix.png" alt="Vibby Partner — Team Phoenix" />
+        </a>
+      </div>
+      <div class="partner">
+        <a href="http://www.mutiny.gg/" target="_blank" title="Visit Mutiny Gaming">
+          <img src="https://s3-eu-west-1.amazonaws.com/vibby-static/LandingPage/esports/partners/partner-esports-mutiny-gaming.png" alt="Vibby Partner — Mutiny Gaming" />
         </a>
       </div>
     </div>


### PR DESCRIPTION
- I added Mutiny Gaming to the Vibby Esports Page. I simply copied the format from one of the other partners and catered it to Mutiny Gaming
- I uploaded the image of Mutiny Gaming's logo to Amazon S3 just as all of the other partner's logos are and I used that link for the Mutiny Gaming image
- I fixed a type for the Team Phoenix section where it still read as "Visit CSadria"
